### PR TITLE
Added the ERB parser to the configuration YML load

### DIFF
--- a/lib/haystack_ruby/config.rb
+++ b/lib/haystack_ruby/config.rb
@@ -15,7 +15,7 @@ module HaystackRuby
     def load!(path, environment = nil)
       require 'yaml'
       environment ||= Rails.env
-      conf = YAML.load(File.new(path).read).with_indifferent_access[environment]
+      conf = YAML.load(ERB.new(File.new(path).read).result).with_indifferent_access[environment]
       load_configuration(conf)
     end
   end


### PR DESCRIPTION
Parses configuration files with the ERB parser during load which will allow users to specify environment variables for configuration which is standard when deploying to a host like Heroku.  In addition, it allows Base64.encode to work inside of the YML itself for the basic authorization setup.  Example configuration with ERB support below.

```
development:
 project1:
   base_url: <%= ENV['HAYSTACK_BASE_URL'] %>
   credentials: <%= Base64.encode64("#{ENV['HAYSTACK_USERNAME']}:#{ENV['HAYSTACK_PASSWORD']}") %> 
   haystack_version: 3.0
   secure: true
```
