### PR TITLE
Boolean and Null Point Values Bug Fix

### DIFF
--- a/lib/haystack_ruby/object.rb
+++ b/lib/haystack_ruby/object.rb
@@ -61,10 +61,10 @@ module HaystackRuby
             else
               raise HaystackRuby::Error, "unrecognized type for string val #{val}"
           end
+          set_fields val
         else
           raise HaystackRuby::Error, "unrecognized type for val #{val}"
         end
-      set_fields val
     end
   end
 end


### PR DESCRIPTION
It appears that `set_fields` is being called out of the string scope. Since booleans, arrays, and nulls do not have an associated type class with a `set_fields` method, an exception is raised. This is preventing boolean values from being read. I have moved the method under the String case and now booleans are being read properly.